### PR TITLE
Move .podspec file to fix 'react-native link', add React dependency

### DIFF
--- a/Countly.podspec
+++ b/Countly.podspec
@@ -33,8 +33,8 @@ Pod::Spec.new do |s|
   s.social_media_url = 'https://twitter.com/gocountly'
   s.author = {'Countly' => 'hello@count.ly'}
   s.source = { :git => 'https://github.com/Countly/countly-sdk-ios.git', :tag => s.version.to_s }
-  s.source_files = '*.{h,m}'
-  s.public_header_files = 'Countly.h', 'CountlyUserDetails.h', 'CountlyConfig.h'
+  s.source_files = 'ios/src/*.{h,m}'
+  s.public_header_files = 'ios/src/Countly.h', 'ios/src/CountlyUserDetails.h', 'ios/src/CountlyConfig.h'
   s.requires_arc = true
   s.ios.deployment_target = '8.0'
   s.osx.deployment_target = '10.10'
@@ -42,7 +42,9 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
 
   s.subspec 'NotificationService' do |ns|
-    ns.source_files = 'CountlyNotificationService.{m,h}'
+    ns.source_files = 'ios/src/CountlyNotificationService.{m,h}'
   end
+
+  s.dependency "React"
 
 end


### PR DESCRIPTION
The .podspec file should be located in the root folder, otherwise `react-native link` doesn't recognize the fact it should add it to the Podfile and links it as a subproject instead.

The other solution to this problem is not to use `react-native link` and manually edit the Podfile to specify the pod like this (In this case the web guide page should be updated):
```
pod 'Countly', :path => '../node_modules/countly-sdk-react-native-bridge/ios/src'
```

The `s.dependency "React"` is needed to link the Countly to React within the Pods target build process.