### PR TITLE
Remove function arguments in disableLocation

### DIFF
--- a/ios/src/CountlyReactNative.m
+++ b/ios/src/CountlyReactNative.m
@@ -333,7 +333,7 @@ RCT_EXPORT_METHOD(setLocation:(NSArray*)arguments)
 
 }
 
-RCT_EXPORT_METHOD(disableLocation:(NSArray*)arguments)
+RCT_EXPORT_METHOD(disableLocation)
 {
   [Countly.sharedInstance disableLocationInfo];
 }


### PR DESCRIPTION
Otherwise JS throws an error, when calling `Countly.disableLocation();` without arguments