### PR TITLE
[SDK-202] Multiple Widgets of same type issue fixed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 20.11.1
 * Issue fixed if same type of multiple surveys/nps widgets available.
-* Added getFeedbackWidgets method to get a list of available feedback widgets.
+* Added getFeedbackWidgets method to get a list of available feedback widgets as array of object to handle multiple widgets of same type.
 * Added presentFeedbackWidgetObject to show/present a feedback widget.
 * Deprecated getAvailableFeedbackWidgets method.
 * Deprecated presentFeedbackWidget method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Added getFeedbackWidgets method to get a list of available feedback widgets.
 * Added presentFeedbackWidgetObject to show/present a feedback widget.
 * Deprecated getAvailableFeedbackWidgets method.
+* Deprecated presentFeedbackWidget method.
 * Updated underlying android SDK to 20.11.2
 * Updated underlying ios SDK to 20.11.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 20.11.1
+* Issue fixed if same type of multiple surveys/nps widgets available.
+* Added getFeedbackWidgets method to get a list of available feedback widgets.
+* Added presentFeedbackWidgetObject to show/present a feedback widget.
+* Deprecated getAvailableFeedbackWidgets method.
+* Updated underlying android SDK to 20.11.2
+* Updated underlying ios SDK to 20.11.1
+
 ## 20.11.0
 * !! Due to cocoapods issue with Xcode 12, we have created a new temporary Pod with a fix for Countly iOS SDK and named it "CounltyPod". Due to that change if you have already add the reference of files "CountlyNotificationService.h/m" then you need to update these files references by adding the files from "CountlyPod" and remove the old reference files.
 * !! Consent change !! To use remote config, you now need to give "remote-config" consent

--- a/Countly.js
+++ b/Countly.js
@@ -634,7 +634,7 @@ Countly.showStarRating = function(callback){
     CountlyReactNative.showStarRating([], callback);
 }
 
-Countly.showFeedbackPopup = function(widgetId, closeButtonText,){
+Countly.showFeedbackPopup = function(widgetId, closeButtonText){
     CountlyReactNative.showFeedbackPopup([widgetId.toString() || "", closeButtonText.toString() || "Done"]);
 }
 
@@ -661,20 +661,34 @@ Countly.getAvailableFeedbackWidgets = async function(){
  * @param {Object} feedbackWidget - feeback Widget with id, type and name
  * @param {String} closeButtonText - text for cancel/close button
  */  
-Countly.presentFeedbackWidgetObject = async function(feedbackWidget, closeButtonText,){
+Countly.presentFeedbackWidgetObject = async function(feedbackWidget, closeButtonText){
+    if(!feedbackWidget) {
+        if(await CountlyReactNative.isLoggingEnabled()) {
+            console.error("[CountlyCordova] presentFeedbackWidgetObject, feedbackWidget should not be null or undefined");
+        }
+        return "feedbackWidget should not be null or undefined";
+    }
     if(!feedbackWidget.id) {
         if(await CountlyReactNative.isLoggingEnabled()) {
-            console.error("[CountlyCordova] presentFeedbackWidget, feedbackWidget id should not be null or empty");
+            console.error("[CountlyCordova] presentFeedbackWidgetObject, feedbackWidget id should not be null or empty");
         }
         return "FeedbackWidget id should not be null or empty";
     }
     if(!feedbackWidget.type) {
         if(await CountlyReactNative.isLoggingEnabled()) {
-            console.error("[CountlyCordova] presentFeedbackWidget, feedbackWidget type should not be null or empty");
+            console.error("[CountlyCordova] presentFeedbackWidgetObject, feedbackWidget type should not be null or empty");
         }
         return "FeedbackWidget type should not be null or empty";
     }
-    CountlyReactNative.presentFeedbackWidget([feedbackWidget.id, feedbackWidget.type, feedbackWidget.name || "", closeButtonText || closeButtonText.toString() || ""]);
+    if (typeof closeButtonText != "string") { 
+            closeButtonText = "";
+            if(await CountlyReactNative.isLoggingEnabled()) {
+            console.warn("[CountlyReactNative] presentFeedbackWidgetObject, unsupported data type of closeButtonText : '" + (typeof args) + "'");
+        }
+    }
+    feedbackWidget.name = feedbackWidget.name || "";
+    closeButtonText = closeButtonText || "";
+    CountlyReactNative.presentFeedbackWidget([feedbackWidget.id, feedbackWidget.type, feedbackWidget.name, closeButtonText]);
 }
 
 /**
@@ -686,7 +700,7 @@ Countly.presentFeedbackWidgetObject = async function(feedbackWidget, closeButton
 
 * @deprecated in 20.11.1 : use 'presentFeedbackWidgetObject' intead of 'presentFeedbackWidget'.
 */  
-Countly.presentFeedbackWidget = function(widgetType, widgetId, closeButtonText,){
+Countly.presentFeedbackWidget = function(widgetType, widgetId, closeButtonText){
     var feedbackWidget = {
         "id": widgetId,
         "type": widgetType

--- a/Countly.js
+++ b/Countly.js
@@ -639,7 +639,7 @@ Countly.showFeedbackPopup = function(widgetId, closeButtonText){
 }
 
 /**
- * Get a list of feedback widgets for this device ID
+ * Get a list of available feedback widgets as array of object to handle multiple widgets of same type.
  */
 Countly.getFeedbackWidgets = async function(){
      const result = await CountlyReactNative.getFeedbackWidgets();
@@ -648,7 +648,10 @@ Countly.getFeedbackWidgets = async function(){
 
 /**
  * Get a list of available feedback widgets for this device ID
- * * @deprecated in 20.11.1 : use 'getFeedbackWidgets' intead of 'getAvailableFeedbackWidgets'.
+ * @deprecated in 20.11.1 : use 'getFeedbackWidgets' intead of 'getAvailableFeedbackWidgets'.
+ * Using the old function it will not be possible to see all the available feedback widgets. 
+ * In case there are multiple ones for the same type, only the last one will be returned due to their id being overwritten in the type field.
+ * The newer function allow also to see the widgets 'name' field which can be further used to filter and identify specific widgets.
  */
 Countly.getAvailableFeedbackWidgets = async function(){
     const result = await CountlyReactNative.getAvailableFeedbackWidgets();
@@ -697,7 +700,6 @@ Countly.presentFeedbackWidgetObject = async function(feedbackWidget, closeButton
 * @param {String} widgetType - type of widget : "nps" or "survey"
 * @param {String} widgetId - id of widget to present
 * @param {String} closeButtonText - text for cancel/close button
-
 * @deprecated in 20.11.1 : use 'presentFeedbackWidgetObject' intead of 'presentFeedbackWidget'.
 */  
 Countly.presentFeedbackWidget = function(widgetType, widgetId, closeButtonText){

--- a/Countly.js
+++ b/Countly.js
@@ -637,23 +637,61 @@ Countly.showStarRating = function(callback){
 Countly.showFeedbackPopup = function(widgetId, closeButtonText,){
     CountlyReactNative.showFeedbackPopup([widgetId.toString() || "", closeButtonText.toString() || "Done"]);
 }
+
 /**
- * Get a list of available feedback widgets for this device ID
+ * Get a list of feedback widgets for this device ID
  */
-Countly.getAvailableFeedbackWidgets = async function(){
-     const result = await CountlyReactNative.getAvailableFeedbackWidgets();
+Countly.getFeedbackWidgets = async function(){
+     const result = await CountlyReactNative.getFeedbackWidgets();
       return result;
   }
 
 /**
+ * Get a list of available feedback widgets for this device ID
+ * * @deprecated in 20.11.1 : use 'getFeedbackWidgets' intead of 'getAvailableFeedbackWidgets'.
+ */
+Countly.getAvailableFeedbackWidgets = async function(){
+    const result = await CountlyReactNative.getAvailableFeedbackWidgets();
+     return result;
+ }
+
+/**
  * Present a chosen feedback widget
  * 
- * @param {String} widgetType - type of widget : "nps" or "survey"
- * @param {String} widgetId - id of widget to present
+ * @param {Object} feedbackWidget - feeback Widget with id, type and name
  * @param {String} closeButtonText - text for cancel/close button
  */  
+Countly.presentFeedbackWidgetObject = async function(feedbackWidget, closeButtonText,){
+    if(!feedbackWidget.id) {
+        if(await CountlyReactNative.isLoggingEnabled()) {
+            console.error("[CountlyCordova] presentFeedbackWidget, feedbackWidget id should not be null or empty");
+        }
+        return "FeedbackWidget id should not be null or empty";
+    }
+    if(!feedbackWidget.type) {
+        if(await CountlyReactNative.isLoggingEnabled()) {
+            console.error("[CountlyCordova] presentFeedbackWidget, feedbackWidget type should not be null or empty");
+        }
+        return "FeedbackWidget type should not be null or empty";
+    }
+    CountlyReactNative.presentFeedbackWidget([feedbackWidget.id, feedbackWidget.type, feedbackWidget.name || "", closeButtonText || closeButtonText.toString() || ""]);
+}
+
+/**
+* Present a chosen feedback widget
+* 
+* @param {String} widgetType - type of widget : "nps" or "survey"
+* @param {String} widgetId - id of widget to present
+* @param {String} closeButtonText - text for cancel/close button
+
+* @deprecated in 20.11.1 : use 'presentFeedbackWidgetObject' intead of 'presentFeedbackWidget'.
+*/  
 Countly.presentFeedbackWidget = function(widgetType, widgetId, closeButtonText,){
-    CountlyReactNative.presentFeedbackWidget([widgetId.toString() || "",widgetType.toString() || "", closeButtonText.toString()]);
+    var feedbackWidget = {
+        "id": widgetId,
+        "type": widgetType
+      };
+    Countly.presentFeedbackWidgetObject(feedbackWidget, closeButtonText)
 }
 
 /**

--- a/CountlyReactNative.podspec
+++ b/CountlyReactNative.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'CountlyReactNative'
-  s.version = '20.11.0'
+  s.version = '20.11.1'
   s.license = {
     :type => 'COMMUNITY',
     :text => <<-LICENSE
@@ -47,5 +47,5 @@ Pod::Spec.new do |s|
   end
 
   s.dependency "React"
-  s.dependency "CountlyPod", '20.11.0'
+  s.dependency "CountlyPod", '20.11.1'
 end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -44,7 +44,7 @@ repositories {
 
 dependencies {
     implementation "com.facebook.react:react-native:${safeExtGet('reactNativeVersion', '+')}"
-    implementation 'ly.count.android:sdk:20.11.1'
+    implementation 'ly.count.android:sdk:20.11.2'
 
     //if any version higher than 18.0.0 is used then it forces AndroidX
     implementation 'com.google.firebase:firebase-messaging:18.0.0'

--- a/example/Example.js
+++ b/example/Example.js
@@ -341,23 +341,25 @@ class Example extends Component {
     }
 
     showSurvey = function(){
-      Countly.getAvailableFeedbackWidgets().then((retrivedWidgets) => {
-          if("survey" in retrivedWidgets) {
-              Countly.presentFeedbackWidget("survey", retrivedWidgets.survey, "Close")
+      Countly.getFeedbackWidgets().then((retrivedWidgets) => {
+          var surveyWidget =  retrivedWidgets.find(x => x.type === 'survey')
+          if(surveyWidget) {
+              Countly.presentFeedbackWidgetObject(surveyWidget, "Close")
           }
       },(err) => {
-          console.error("[CountlyCordova] getAvailableFeedbackWidgets error : " +err);
+          console.error("[CountlyCordova] getFeedbackWidgets error : " +err);
       });
   }
 
   showNPS = function(){
-      Countly.getAvailableFeedbackWidgets().then((retrivedWidgets) => {
-          if("nps" in retrivedWidgets) {
-              Countly.presentFeedbackWidget("nps", retrivedWidgets.survey, "Cancel")
-          }
-      },(err) => {
-          console.error("[CountlyCordova] getAvailableFeedbackWidgets error : " +err);
-      });
+    Countly.getFeedbackWidgets().then((retrivedWidgets) => {
+      var npsWidget =  retrivedWidgets.find(x => x.type === 'nps')
+      if(npsWidget) {
+          Countly.presentFeedbackWidgetObject(npsWidget, "Close")
+      }
+  },(err) => {
+      console.error("[CountlyCordova] getFeedbackWidgets error : " +err);
+  });
   }
 
     addCrashLog(){

--- a/example/install.sh
+++ b/example/install.sh
@@ -11,7 +11,7 @@ rm App.js
 curl https://raw.githubusercontent.com/Countly/countly-sdk-react-native-bridge/master/example/App.js --output App.js
 curl https://raw.githubusercontent.com/Countly/countly-sdk-react-native-bridge/master/example/Example.js --output Example.js
 
-yarn add countly-sdk-react-native-bridge@20.11.0
+yarn add countly-sdk-react-native-bridge@20.11.1
 npm install --save https://github.com/ijunaid/react-native-advertising-id.git
 
 cd ./ios

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -2,5 +2,5 @@ platform :ios, '8.0'
 
 target 'countly-sdk-react-native-bridge' do
   use_frameworks!
-  pod 'CountlyPod', "20.11.0"
+  pod 'CountlyPod', "20.11.1"
 end

--- a/ios/src/CountlyReactNative.m
+++ b/ios/src/CountlyReactNative.m
@@ -21,7 +21,7 @@
 + (CountlyFeedbackWidget *)createWithDictionary:(NSDictionary *)dictionary;
 @end
 
-NSString* const kCountlyReactNativeSDKVersion = @"20.11.0";
+NSString* const kCountlyReactNativeSDKVersion = @"20.11.1";
 NSString* const kCountlyReactNativeSDKName = @"js-rnb-ios";
 
 CountlyConfig* config = nil;
@@ -853,6 +853,25 @@ RCT_EXPORT_METHOD(showFeedbackPopup:(NSArray*)arguments)
   });
 }
 
+RCT_REMAP_METHOD(getFeedbackWidgets,
+                 getFeedbackWidgetsWithResolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+  dispatch_async(dispatch_get_main_queue(), ^ {
+    [Countly.sharedInstance getFeedbackWidgets:^(NSArray<CountlyFeedbackWidget *> * _Nonnull feedbackWidgets, NSError * _Nonnull error) {
+      NSMutableArray* feedbackWidgetsArray = [NSMutableArray arrayWithCapacity:feedbackWidgets.count];
+      for (CountlyFeedbackWidget* retrievedWidget in feedbackWidgets) {
+          NSMutableDictionary* feedbackWidget = [NSMutableDictionary dictionaryWithCapacity:3];
+          feedbackWidget[@"id"] = retrievedWidget.ID;
+          feedbackWidget[@"type"] = retrievedWidget.type;
+          feedbackWidget[@"name"] = retrievedWidget.name;
+          [feedbackWidgetsArray addObject:feedbackWidget];
+      }
+      resolve(feedbackWidgetsArray);
+    }];
+  });
+}
+
 RCT_REMAP_METHOD(getAvailableFeedbackWidgets,
                  getAvailableFeedbackWidgetsWithResolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
@@ -873,11 +892,12 @@ RCT_EXPORT_METHOD(presentFeedbackWidget:(NSArray*)arguments)
   dispatch_async(dispatch_get_main_queue(), ^ {
         NSString* widgetId = [arguments objectAtIndex:0];
         NSString* widgetType = [arguments objectAtIndex:1];
+        NSString* widgetName = [arguments objectAtIndex:2];
             NSMutableDictionary* feedbackWidgetsDict = [NSMutableDictionary dictionaryWithCapacity:3];
             
             feedbackWidgetsDict[@"_id"] = widgetId;
             feedbackWidgetsDict[@"type"] = widgetType;
-            feedbackWidgetsDict[@"name"] = widgetType;
+            feedbackWidgetsDict[@"name"] = widgetName;
             CountlyFeedbackWidget *feedback = [CountlyFeedbackWidget createWithDictionary:feedbackWidgetsDict];
             [feedback present];
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "countly-sdk-react-native-bridge",
-  "version": "20.11.0",
+  "version": "20.11.1",
   "author": "Countly <hello@count.ly> (https://count.ly/)",
   "bugs": {
     "url": "https://github.com/Countly/countly-sdk-react-native-bridge/issues"


### PR DESCRIPTION
— Issue fixed if same type of multiple surveys/nps widgets available.
— Added getFeedbackWidgets method to get a list of available feedback widgets.
— Added presentFeedbackWidgetObject to show/present a feedback widget.
— Deprecated getAvailableFeedbackWidgets method.
— Deprecated presentFeedbackWidget method.
— Updated underlying android SDK to 20.11.2
— Updated underlying ios SDK to 20.11.1