### PR TITLE
fix getCurrentDeviceId on android

### DIFF
--- a/android/src/main/java/ly/count/android/sdk/react/CountlyReactNative.java
+++ b/android/src/main/java/ly/count/android/sdk/react/CountlyReactNative.java
@@ -182,15 +182,15 @@ public class CountlyReactNative extends ReactContextBaseJavaModule implements Li
     }
     
     @ReactMethod
-    public void getCurrentDeviceId(ReadableArray args, final Callback myCallback){
+    public void getCurrentDeviceId(Promise promise){
         String deviceID = Countly.sharedInstance().getDeviceID();
         if (deviceID == null) {
             log("getCurrentDeviceId, deviceIdNotFound", LogLevel.DEBUG);
-            myCallback.invoke("deviceIdNotFound");
+            promise.resolve("deviceIdNotFound");
         }
         else {
             log("getCurrentDeviceId: " + deviceID, LogLevel.DEBUG);
-            myCallback.invoke(deviceID);
+            promise.resolve(deviceID);
         }
     }
 


### PR DESCRIPTION
Hello.

On latest release (20.11.5) as well as on master calling something something like `const deviceId = yield Countly.getCurrentDeviceId();` on Android causes the following error:
<img src="https://user-images.githubusercontent.com/64093836/112672246-50548900-8e74-11eb-9ba1-45c45001ea13.png" alt="getCurrentDeviceId error" width="300">

The call is in `Countly.js` line 273:
```js
      const result = await CountlyReactNative.getCurrentDeviceId();
```

Indeed no args are passed and this is the actual native method:
```java
    @ReactMethod
    public void getCurrentDeviceId(ReadableArray args, final Callback myCallback){
        String deviceID = Countly.sharedInstance().getDeviceID();
        if (deviceID == null) {
            log("getCurrentDeviceId, deviceIdNotFound", LogLevel.DEBUG);
            myCallback.invoke("deviceIdNotFound");
        }
        else {
            log("getCurrentDeviceId: " + deviceID, LogLevel.DEBUG);
            myCallback.invoke(deviceID);
        }
    }
```

This PR fixes the `getCurrentDeviceId` method to make it work in a similar fashion to other methods in this library (by taking and resolving promises).

EDIT: Specify the issue is android only.