### PR TITLE
fix getCurrentDeviceId on ios

### DIFF
--- a/ios/src/CountlyReactNative.h
+++ b/ios/src/CountlyReactNative.h
@@ -17,7 +17,6 @@ typedef void (^Result)(id _Nullable result);
 - (void)enableCrashReporting;
 - (void)addCrashLog:(NSArray*_Nullable)arguments;
 
-- (void)getCurrentDeviceId:(NSArray*_Nullable)arguments callback:(RCTResponseSenderBlock _Nullable)callback;
 - (void)getDeviceIdAuthor:(NSArray*_Nullable)arguments callback:(RCTResponseSenderBlock _Nullable)callback;
 - (void)changeDeviceId:(NSArray*_Nullable)arguments;
 - (void)enableParameterTamperingProtection:(NSArray*_Nullable)arguments;

--- a/ios/src/CountlyReactNative.m
+++ b/ios/src/CountlyReactNative.m
@@ -286,16 +286,18 @@ RCT_EXPORT_METHOD(stop)
   // [Countly.sharedInstance suspend];
 }
 
-RCT_EXPORT_METHOD(getCurrentDeviceId:(NSArray*)arguments callback:(RCTResponseSenderBlock)callback)
+RCT_REMAP_METHOD(getCurrentDeviceId,
+                 getCurrentDeviceIdWithResolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
 {
   dispatch_async(dispatch_get_main_queue(), ^ {
   id value = [Countly.sharedInstance deviceID];
   if(value){
-    callback(@[value]);
+    resolve(value);
   }
   else{
     NSString *value = @"deviceIdNotFound";
-    callback(@[value]);
+    resolve(value);
   }
   });
 }


### PR DESCRIPTION
This is related to https://github.com/Countly/countly-sdk-react-native-bridge/pull/51.

I didn't have an oportunity to test on iOS at the time, but it appears that similar issue has been present there all along too.

This MR fixes this error when calling `Countly.getCurrentDeviceId()`.
<img src="https://user-images.githubusercontent.com/64093836/113340764-f69d0480-9334-11eb-8ba3-c0a482353c22.png" alt="getCurrentDeviceId error" width="350">