### PR TITLE
Fix/ios countly warning

### DIFF
--- a/ios/src/CountlyReactNative.m
+++ b/ios/src/CountlyReactNative.m
@@ -59,6 +59,12 @@ NSString* const kCountlyNotificationPersistencyKey = @"kCountlyNotificationPersi
 	
 	return self;
 }
+
++ (BOOL)requiresMainQueueSetup
+{
+  return NO;
+}
+
 - (NSArray<NSString *> *)supportedEvents {
     return @[pushNotificationCallbackName, ratingWidgetCallbackName, widgetShownCallbackName, widgetClosedCallbackName];
 }


### PR DESCRIPTION
On startup, app reports a yellow box warning:
Warning
Module CountlyReactNative requires main queue setup since it overrides init but doesn't implement ``requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explocitly opted-out of.

Explicit defining this method fixed the warning
