### PR TITLE
add notification accent color support for android 12+

### DIFF
--- a/Countly.js
+++ b/Countly.js
@@ -142,6 +142,7 @@ _configToJson = function (config) {
             pushNotification['tokenType'] = config.tokenType;
             pushNotification['channelName'] = config.channelName;
             pushNotification['channelDescription'] = config.channelDescription;
+            pushNotification['accentColor'] = config.accentColor;
             json['pushNotification'] = pushNotification;
         }
         if (config.allowedIntentClassNames) {

--- a/CountlyConfig.js
+++ b/CountlyConfig.js
@@ -136,11 +136,13 @@ class CountlyConfig {
     * @param {TokenType} tokenType token type
     * @param {String} channelName channel name
     * @param {String} channelDescription channel description
+    * @param {String} accentColor notification accent color
     */
-    pushTokenType(tokenType, channelName, channelDescription) {
+    pushTokenType(tokenType, channelName, channelDescription, accentColor) {
         this.tokenType = tokenType;
         this.channelName = channelName;
         this.channelDescription = channelDescription;
+        this.accentColor = accentColor;
         return this;
     }
 

--- a/android/src/main/java/ly/count/android/sdk/react/CountlyReactNative.java
+++ b/android/src/main/java/ly/count/android/sdk/react/CountlyReactNative.java
@@ -1,6 +1,7 @@
 package ly.count.android.sdk.react;
 
 import android.app.Activity;
+import android.graphics.Color;
 import android.media.AudioAttributes;
 import android.net.Uri;
 import android.util.Log;
@@ -228,6 +229,9 @@ public class CountlyReactNative extends ReactContextBaseJavaModule implements Li
                 int messagingMode = Integer.parseInt(pushObject.getString("tokenType"));
                 channelName = pushObject.getString("channelName");
                 channelDescription = pushObject.getString("channelDescription");
+                if (pushObject.has("accentColor")) {
+                    setHexNotificationAccentColor(pushObject.getString("accentColor"));
+                }
 
                 if (messagingMode == 0) {
                     CountlyReactNative.messagingMode = Countly.CountlyMessagingMode.PRODUCTION;
@@ -294,6 +298,20 @@ public class CountlyReactNative extends ReactContextBaseJavaModule implements Li
             }
         } catch (Exception e) {
             log(e.toString(), LogLevel.DEBUG);
+        }
+    }
+
+    private void setHexNotificationAccentColor(final String hex) {
+        try {
+            int color = Color.parseColor(hex);
+            CountlyPush.setNotificationAccentColor(
+                Color.alpha(color),
+                Color.red(color),
+                Color.green(color),
+                Color.blue(color)
+            );
+        } catch (IllegalArgumentException e) {
+            log("setHexNotificationAccentColor: invalid HEX color value: " + hex + " Error: " + e, LogLevel.DEBUG);
         }
     }
 


### PR DESCRIPTION
Extending `CountlyConfig` to use already implemented `setNotificationAccentColor` method to set the notification accent color.